### PR TITLE
build.sh: Move error-checking flag out of shebang

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 
 export CORRETTO_ARCHIVE=amazon-corretto-17-x64-linux-jdk.tar.gz
 export CORRETTO_URL=https://corretto.aws/downloads/latest/${CORRETTO_ARCHIVE}


### PR DESCRIPTION
Always enable error checking (e.g. in cases where invoking `bash ./build.sh` or `. ./build.sh` when shebang is not evaluated)