### PR TITLE
Fixed one-time analysis process (instead of require analysis twice)

### DIFF
--- a/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
+++ b/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
@@ -26,6 +26,7 @@ import java.io.FileNotFoundException;
 import generic.jar.ResourceFile;
 import ghidra.GhidraApplicationLayout;
 import ghidra.app.services.AbstractAnalyzer;
+import ghidra.app.services.AnalysisPriority;
 import ghidra.app.services.AnalyzerType;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.framework.Application;
@@ -54,6 +55,7 @@ public class XbeXbSymbolDatabaseAnalyzer extends AbstractAnalyzer {
 
 	public XbeXbSymbolDatabaseAnalyzer() {
 		super("Xbox Symbol Database Analyzer", "Scan XBE for known library functions", AnalyzerType.BYTE_ANALYZER);
+		setPriority(AnalysisPriority.DISASSEMBLY.before());
 	}
 
 	@Override


### PR DESCRIPTION
I finally found out how Ghidra made their priority setter in a certain order. With this pull request, we can perform a one-time analysis instead of a "two"-times analysis to complete the picture of disassembled functions.

resolve #15 issue