### PR TITLE
Rename XbSymbolDatabaseTool to upstream name (XbSymbolDatabaseCLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ dist/
 /bin/
 .classpath
 .project
-XbSymbolDatabaseTool*
+XbSymbolDatabaseCLI*
 src/main/java/XbeLoader/XbeXtlidDb.java

--- a/build.sh
+++ b/build.sh
@@ -49,16 +49,16 @@ export XBSYMBOLDATABASE=$PWD/XbSymbolDatabase
 popd # Back to source root
 
 # Copy XbSymbolDatabase into this source tree for redist
-cp $XBSYMBOLDATABASE/linux_x64/bin/XbSymbolDatabaseCLI	os/linux_x86_64/XbSymbolDatabaseTool
-cp $XBSYMBOLDATABASE/LICENSE					os/linux_x86_64/XbSymbolDatabaseTool.LICENSE
-cp $XBSYMBOLDATABASE/macos_x64/bin/XbSymbolDatabaseCLI	os/mac_x86_64/XbSymbolDatabaseTool
-cp $XBSYMBOLDATABASE/LICENSE					os/mac_x86_64/XbSymbolDatabaseTool.LICENSE
-cp $XBSYMBOLDATABASE/win_x64/bin/XbSymbolDatabaseCLI.exe	os/win_x86_64/XbSymbolDatabaseTool.exe
-cp $XBSYMBOLDATABASE/LICENSE					os/win_x86_64/XbSymbolDatabaseTool.LICENSE
+cp $XBSYMBOLDATABASE/linux_x64/bin/XbSymbolDatabaseCLI   os/linux_x86_64/XbSymbolDatabaseCLI
+cp $XBSYMBOLDATABASE/LICENSE                             os/linux_x86_64/XbSymbolDatabaseCLI.LICENSE
+cp $XBSYMBOLDATABASE/macos_x64/bin/XbSymbolDatabaseCLI   os/mac_x86_64/XbSymbolDatabaseCLI
+cp $XBSYMBOLDATABASE/LICENSE                             os/mac_x86_64/XbSymbolDatabaseCLI.LICENSE
+cp $XBSYMBOLDATABASE/win_x64/bin/XbSymbolDatabaseCLI.exe os/win_x86_64/XbSymbolDatabaseCLI.exe
+cp $XBSYMBOLDATABASE/LICENSE                             os/win_x86_64/XbSymbolDatabaseCLI.LICENSE
 
 # Add execute permissions to Linux and macOS XbSymbolDatabase binaries
-chmod +x os/linux_x86_64/XbSymbolDatabaseTool
-chmod +x os/mac_x86_64/XbSymbolDatabaseTool
+chmod +x os/linux_x86_64/XbSymbolDatabaseCLI
+chmod +x os/mac_x86_64/XbSymbolDatabaseCLI
 
 echo "[*] Building..."
 xsltproc -o src/main/java/XbeLoader/XbeXtlidDb.java xtlid2java.xslt /tmp/xtlid.xml

--- a/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
+++ b/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
@@ -49,8 +49,8 @@ import ghidra.util.exception.*;
  */
 public class XbeXbSymbolDatabaseAnalyzer extends AbstractAnalyzer {
 	
-	private static final String xbsdb_tool_exec = "XbSymbolDatabaseTool";
-	private static final String xbsdb_tool_exec_wins = "XbSymbolDatabaseTool.exe";
+	private static final String xbsdb_tool_exec = "XbSymbolDatabaseCLI";
+	private static final String xbsdb_tool_exec_wins = "XbSymbolDatabaseCLI.exe";
 
 	public XbeXbSymbolDatabaseAnalyzer() {
 		super("Xbox Symbol Database Analyzer", "Scan XBE for known library functions", AnalyzerType.BYTE_ANALYZER);


### PR DESCRIPTION
This is mainly to keep aligned with the upstream cli tool supplied by XbSymbolDatabase's releases. Plus can be easier to replace the file directly once than to copy it into a directory, delete the old file, and rename the new file steps.