### PR TITLE
Use exception details instead of generic fail message

### DIFF
--- a/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
+++ b/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
@@ -122,14 +122,13 @@ public class XbeXbSymbolDatabaseAnalyzer extends AbstractAnalyzer {
 			}
 			
 			exec.waitFor();
-		} catch (InterruptedException e) {
-			log.appendMsg("Failed to run " + toolExec);
-			return false;
-		} catch (IOException e) {
-			log.appendMsg("Failed to run " + toolExec);
-			return false;
-		} catch (InvalidInputException e) {
-			log.appendMsg("Failed to run " + toolExec);
+		} catch (Throwable e) {
+			int st_i = 0;
+			for (StackTraceElement stackTrace : e.getStackTrace()) {
+				log.appendMsg("stack[" + st_i + "]     : " + stackTrace.toString());
+				st_i++;
+			}
+			log.appendMsg("message      : " + e.getMessage());
 			return false;
 		}
 


### PR DESCRIPTION
Include stack trace and message for a better understanding of the origin of faulty code.

This was not directly to improve #67 issue readability. But for myself encountered an issue with major work in progress to support the future extended information option.

The function I had worked on does work correctly. Except, this pull request was not tested with the reused code but with fewer details.